### PR TITLE
Added github repo to CPAN metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,8 @@
 Revision history for Text::Info
 
+0.02    2015-11-28
+        - Added [GithubMeta] to dist.ini, so the dist metadata will include
+          the github repo details
+
 0.01    2015-08-30
         - Initial release.

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Text::Info
 
 0.02    2015-11-28
+        - Added [MetaJSON] to dist.ini, so releases will include META.json
         - Added [GithubMeta] to dist.ini, so the dist metadata will include
           the github repo details
 

--- a/dist.ini
+++ b/dist.ini
@@ -16,3 +16,5 @@ ExtUtils::MakeMaker = 6.64
 
 [Prereqs / TestRequires]
 Test::More = 0.98
+
+[GithubMeta]

--- a/dist.ini
+++ b/dist.ini
@@ -17,4 +17,5 @@ ExtUtils::MakeMaker = 6.64
 [Prereqs / TestRequires]
 Test::More = 0.98
 
+[MetaJSON]
 [GithubMeta]


### PR DESCRIPTION
Hi,

This ensures that the repo URL will be included in the dist metadata. It will then appear in the sidebar on MetaCPAN, and various other tools will pick it up as well.

I noticed you're using `[VersionFromModule]` in `dist.ini`. Have you thought about using `[PkgVersion]`, which will add `$VERSION` lines to all of your module, based on a version you set in `dist.ini`? That means you don't have to edit every `.pm` file in every release, and ensures that all modules have a version number that matches the release version.

Cheers,
Neil
